### PR TITLE
Upload logs in batches and reduce memory usage

### DIFF
--- a/src/main/java/com/nccgroup/loggerplusplus/exports/CobaltExporter.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/exports/CobaltExporter.java
@@ -169,6 +169,7 @@ public class CobaltExporter extends AutomaticLogExporter implements ExportPanelP
                     if (statusCode >= 400) {
                         LoggerPlusPlus.callbacks.printOutput(EntityUtils.toString(response.getEntity()));
                     }
+                    response.close();
                     connectFailedCounter = 0;
                 } catch (ConnectException e) {
                     LoggerPlusPlus.callbacks.printError("Connection error, upload failed");

--- a/src/main/java/com/nccgroup/loggerplusplus/exports/CobaltExporter.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/exports/CobaltExporter.java
@@ -160,7 +160,7 @@ public class CobaltExporter extends AutomaticLogExporter implements ExportPanelP
 
             for (List<LogEntry> entries : batchEntries) {
                 try {
-                    LoggerPlusPlus.callbacks.printOutput("Uploading pending log entries (" + entries.size() + ")...");
+                    LoggerPlusPlus.callbacks.printOutput("Uploading 1 message with " + entries.size() + " log entries...");
                     post.setEntity(buildRequestBody((ArrayList<LogEntry>) entries));
                     CloseableHttpResponse response = httpClient.execute(post);
                     int statusCode = response.getStatusLine().getStatusCode();

--- a/src/test/java/com/nccgroup/loggerplusplus/exports/CobaltExporterTest.java
+++ b/src/test/java/com/nccgroup/loggerplusplus/exports/CobaltExporterTest.java
@@ -10,7 +10,6 @@ import org.apache.http.entity.StringEntity;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;


### PR DESCRIPTION
To reduce the excessive memory usage following changes are made,

1. `scheduleWithFixedDelay` is used instead of `scheduleAtFixedRate`, so that next thread runs only after the completion of the previous thread.
2. Closed the http connection after receiving response.
3. Logs will be uploaded in batches (max 50 logs).